### PR TITLE
Add dependency to AppD maven central plugin via framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -4,11 +4,13 @@
 	<description>AppDynamics EUM API Plugin</description>
 	<keywords>appdynamics,rum</keywords>
 	<author>Steve W</author>
-	
+
 	<engines>
 		<engine name="cordova" version=">=3.9.1"/>
 	</engines>
-	
+
+	<framework src="com.appdynamics:appdynamics-runtime:4.+" />
+
 	<!--
 	Apple iOS
 	-->
@@ -19,13 +21,13 @@
 				<param name="onload" value="true"/>
 			</feature>
 		</config-file>
-		
+
 		<header-file src="src/ios/AppDynamicsAPI.h"/>
 		<source-file src="src/ios/AppDynamicsAPI.m"/>
 		<header-file src="src/ios/AppDCache.h"/>
 		<source-file src="src/ios/AppDCache.m"/>
 	</platform>
-	
+
 	<!--
 	Android
 	-->
@@ -35,9 +37,9 @@
 				<param name="android-package" value="com.appdynamics.appdplugin.AppDynamicsAPI"/>
 			</feature>
 		</config-file>
-		
+
 		<source-file src="src/com/appdynamics/appdplugin/AppDynamicsAPI.java" target-dir="src/com/appdynamics/appdplugin"/>
 		<source-file src="src/com/appdynamics/appdplugin/SharedCache.java" target-dir="src/com/appdynamics/appdplugin"/>
 	</platform>
-	
+
 </plugin>


### PR DESCRIPTION
Cordova plugins may comtribute gradle dependencies via the
[framework](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#framework) element in their plugin.xml.  This simplifies setup somewhat for gradle-based builds, in that they do not need to add the `compile 'com.appdynamics:appdynamics-runtime:4.+'` dependency. They still need to add the `classpath 'com.appdynamics:appdynamics-gradle-plugin:4.+'` dependency and follow the [setup instructions](https://docs.appdynamics.com/display/PRO42/Instrument+an+Android+Application+-+Maven+Central#InstrumentanAndroidApplication-MavenCentral-step43.SetUpYourEnvironment) to configure the adeum plugin.